### PR TITLE
grfana service port change 80 to 3000

### DIFF
--- a/yaml/prometheus/new/grafana-service.yml
+++ b/yaml/prometheus/new/grafana-service.yml
@@ -9,7 +9,7 @@ metadata:
 spec:
   type: LoadBalancer
   ports:
-    - port: 80
+    - port: 3000
       targetPort: 3000
   selector:
     app: grafana


### PR DESCRIPTION
之前的grafana service 使用 80 端口的化，导入 dashboard 会失败，因为导入的使用的 URL：grafana:3000